### PR TITLE
Home Page UI + Implementation to AppBar

### DIFF
--- a/app/lib/features/dashboard/pages/user_progress_dashboard.dart
+++ b/app/lib/features/dashboard/pages/user_progress_dashboard.dart
@@ -53,10 +53,10 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   void initState() {
     super.initState();
     _screens = [
+      const HomeScreen(),
       const UserProgressDashboard(),
       const DailyChallengePage(),
       const ProfilePagePlaceholder(),
-      const HomeScreen(),
     ];
   }
 
@@ -96,7 +96,12 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
             fontSize: 12,
           ),
           elevation: 0,
-          items: const [        
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.local_activity),
+              activeIcon: Icon(Icons.local_activity),
+              label: 'Home', 
+            ),         
             BottomNavigationBarItem(
               icon: Icon(Icons.dashboard_outlined),
               activeIcon: Icon(Icons.dashboard),
@@ -111,12 +116,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               icon: Icon(Icons.person_outline),
               activeIcon: Icon(Icons.person),
               label: 'Profile',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.local_activity),
-              activeIcon: Icon(Icons.local_activity),
-              label: 'Home', 
-            ),                
+            ),               
           ],
         ),
       ),

--- a/app/lib/features/dashboard/pages/user_progress_dashboard.dart
+++ b/app/lib/features/dashboard/pages/user_progress_dashboard.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+import 'package:app/features/homescreen/pages/home_page.dart';
 import 'package:provider/provider.dart';
 import 'package:app/pace%20selector/pace_selector.dart';
 import 'package:flutter/material.dart';
@@ -55,6 +56,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       const UserProgressDashboard(),
       const DailyChallengePage(),
       const ProfilePagePlaceholder(),
+      const HomeScreen(),
     ];
   }
 
@@ -94,7 +96,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
             fontSize: 12,
           ),
           elevation: 0,
-          items: const [
+          items: const [        
             BottomNavigationBarItem(
               icon: Icon(Icons.dashboard_outlined),
               activeIcon: Icon(Icons.dashboard),
@@ -110,6 +112,11 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               activeIcon: Icon(Icons.person),
               label: 'Profile',
             ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.local_activity),
+              activeIcon: Icon(Icons.local_activity),
+              label: 'Home', 
+            ),                
           ],
         ),
       ),

--- a/app/lib/features/dashboard/pages/user_progress_dashboard.dart
+++ b/app/lib/features/dashboard/pages/user_progress_dashboard.dart
@@ -56,7 +56,6 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       const UserProgressDashboard(),
       const DailyChallengePage(),
       const ProfilePagePlaceholder(),
-      const HomeScreen(),
     ];
   }
 
@@ -111,12 +110,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               icon: Icon(Icons.person_outline),
               activeIcon: Icon(Icons.person),
               label: 'Profile',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.local_activity),
-              activeIcon: Icon(Icons.local_activity),
-              label: 'Home', 
-            ),                
+            ),               
           ],
         ),
       ),

--- a/app/lib/features/dashboard/pages/user_progress_dashboard.dart
+++ b/app/lib/features/dashboard/pages/user_progress_dashboard.dart
@@ -56,6 +56,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       const UserProgressDashboard(),
       const DailyChallengePage(),
       const ProfilePagePlaceholder(),
+      const HomeScreen(),
     ];
   }
 
@@ -110,7 +111,12 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
               icon: Icon(Icons.person_outline),
               activeIcon: Icon(Icons.person),
               label: 'Profile',
-            ),               
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.local_activity),
+              activeIcon: Icon(Icons.local_activity),
+              label: 'Home', 
+            ),                
           ],
         ),
       ),

--- a/app/lib/features/homescreen/pages/home_page.dart
+++ b/app/lib/features/homescreen/pages/home_page.dart
@@ -1,0 +1,41 @@
+import 'package:app/core/constants/colors.dart';
+import 'package:app/features/homescreen/widgets/user_info_box.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class HomeScreen extends StatefulWidget { 
+    const HomeScreen({super.key});
+    
+    @override
+    State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+    @override 
+    Widget build(BuildContext context) {
+        return Scaffold(
+            backgroundColor: AppColors.background,
+            appBar: AppBar(
+                title: const Text(
+                    'Home Page',
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                ),
+                backgroundColor: AppColors.cardBackground,
+                foregroundColor: AppColors.textPrimary,
+                elevation: 0,
+                systemOverlayStyle: SystemUiOverlayStyle.dark,
+                automaticallyImplyLeading: false,
+            ),
+            body: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const UserInfoBox(
+                  name: "Peter Griffin",
+                  avatarURL: "https://www.applesfromny.com/wp-content/uploads/2020/06/SnapdragonNEW.png",
+                  proficiencyLevel: "Intermediate Student",
+                ),
+              ]              
+            )
+        );
+    }
+}

--- a/app/lib/features/homescreen/pages/home_page.dart
+++ b/app/lib/features/homescreen/pages/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:app/core/constants/colors.dart';
 import 'package:app/features/homescreen/widgets/user_info_box.dart';
+import 'package:app/features/homescreen/widgets/welcome_box.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:app/features/homescreen/widgets/home_sections.dart';
@@ -21,24 +22,29 @@ class _HomeScreenState extends State<HomeScreen> {
           'Home Page',
           style: TextStyle(fontWeight: FontWeight.w600),
         ),
-        backgroundColor: AppColors.cardBackground,
-        foregroundColor: AppColors.textPrimary,
+        backgroundColor: AppColors.primary,
+        foregroundColor: AppColors.background,
         elevation: 0,
         systemOverlayStyle: SystemUiOverlayStyle.dark,
         automaticallyImplyLeading: false,
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const UserInfoBox(
-            name: "Maria Hernandez",
-            avatarURL:
-                "https://www.applesfromny.com/wp-content/uploads/2020/06/SnapdragonNEW.png",
-            proficiencyLevel: "Intermediate Student",
-          ),
-          const SizedBox(height: 16), // Espacio
-          const HomeSections(),
-        ],
+      body: SingleChildScrollView(
+        child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+                const UserInfoBox(
+                    name: "Maria Hernandez",
+                    avatarURL: "https://www.applesfromny.com/wp-content/uploads/2020/06/SnapdragonNEW.png",
+                    proficiencyLevel: "Intermediate Student",
+                ),
+                const SizedBox(height: 10),
+                const WelcomeBackBox(
+                    name: "Maria", 
+                ),
+                const SizedBox(height: 16), // Espacio
+                const HomeSections(),
+           ],
+        ),
       ),
     );
   }

--- a/app/lib/features/homescreen/pages/home_page.dart
+++ b/app/lib/features/homescreen/pages/home_page.dart
@@ -2,40 +2,44 @@ import 'package:app/core/constants/colors.dart';
 import 'package:app/features/homescreen/widgets/user_info_box.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:app/features/homescreen/widgets/home_sections.dart';
 
-class HomeScreen extends StatefulWidget { 
-    const HomeScreen({super.key});
-    
-    @override
-    State<HomeScreen> createState() => _HomeScreenState();
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-    @override 
-    Widget build(BuildContext context) {
-        return Scaffold(
-            backgroundColor: AppColors.background,
-            appBar: AppBar(
-                title: const Text(
-                    'Home Page',
-                    style: TextStyle(fontWeight: FontWeight.w600),
-                ),
-                backgroundColor: AppColors.cardBackground,
-                foregroundColor: AppColors.textPrimary,
-                elevation: 0,
-                systemOverlayStyle: SystemUiOverlayStyle.dark,
-                automaticallyImplyLeading: false,
-            ),
-            body: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const UserInfoBox(
-                  name: "Maria Hernandez",
-                  avatarURL: "https://www.applesfromny.com/wp-content/uploads/2020/06/SnapdragonNEW.png",
-                  proficiencyLevel: "Intermediate Student",
-                ),
-              ]              
-            )
-        );
-    }
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: const Text(
+          'Home Page',
+          style: TextStyle(fontWeight: FontWeight.w600),
+        ),
+        backgroundColor: AppColors.cardBackground,
+        foregroundColor: AppColors.textPrimary,
+        elevation: 0,
+        systemOverlayStyle: SystemUiOverlayStyle.dark,
+        automaticallyImplyLeading: false,
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const UserInfoBox(
+            name: "Maria Hernandez",
+            avatarURL:
+                "https://www.applesfromny.com/wp-content/uploads/2020/06/SnapdragonNEW.png",
+            proficiencyLevel: "Intermediate Student",
+          ),
+          const SizedBox(height: 16), // Espacio
+          const HomeSections(),
+        ],
+      ),
+    );
+  }
 }

--- a/app/lib/features/homescreen/pages/home_page.dart
+++ b/app/lib/features/homescreen/pages/home_page.dart
@@ -29,7 +29,11 @@ class _HomeScreenState extends State<HomeScreen> {
             body: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text("test"),
+                const UserInfoBox(
+                  name: "Maria Hernandez",
+                  avatarURL: "https://www.applesfromny.com/wp-content/uploads/2020/06/SnapdragonNEW.png",
+                  proficiencyLevel: "Intermediate Student",
+                ),
               ]              
             )
         );

--- a/app/lib/features/homescreen/pages/home_page.dart
+++ b/app/lib/features/homescreen/pages/home_page.dart
@@ -29,11 +29,7 @@ class _HomeScreenState extends State<HomeScreen> {
             body: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const UserInfoBox(
-                  name: "Peter Griffin",
-                  avatarURL: "https://www.applesfromny.com/wp-content/uploads/2020/06/SnapdragonNEW.png",
-                  proficiencyLevel: "Intermediate Student",
-                ),
+                Text("test"),
               ]              
             )
         );

--- a/app/lib/features/homescreen/widgets/home_sections.dart
+++ b/app/lib/features/homescreen/widgets/home_sections.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+class HomeSections extends StatelessWidget {
+  const HomeSections({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: const [
+        ActivityCard(
+          icon: Icons.menu_book,
+          title: 'Lessons',
+          subtitle: '12 available',
+          trailing: Text(
+            'Pronunciation',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
+          ),
+        ),
+        ActivityCard(
+          icon: Icons.mic,
+          title: 'Daily Practice',
+          subtitle: '5 minutes left',
+          trailing: CircleAvatar(
+            radius: 14,
+            backgroundColor: Colors.greenAccent,
+            child: Text(
+              '3/5',
+              style: TextStyle(fontSize: 12, color: Colors.black87),
+            ),
+          ),
+        ),
+        ActivityCard(
+          icon: Icons.flag,
+          title: 'Objetivos semanales',
+          subtitle: '4 of 7 days completed',
+          trailing: Icon(Icons.remove, color: Colors.orange, size: 20),
+        ),
+      ],
+    );
+  }
+}
+
+class ActivityCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final Widget trailing;
+
+  const ActivityCard({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () {
+          debugPrint('$title tapped!');
+        },
+        splashColor: Colors.blueAccent.withOpacity(0.2),
+        highlightColor: Colors.blueAccent.withOpacity(0.05),
+        child: ListTile(
+          leading: Icon(icon, size: 30, color: Colors.blueAccent),
+          title: Text(
+            title,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          subtitle: Text(subtitle),
+          trailing: trailing,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/homescreen/widgets/user_info_box.dart
+++ b/app/lib/features/homescreen/widgets/user_info_box.dart
@@ -32,7 +32,52 @@ class UserInfoBox extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('test'),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              CircleAvatar(
+                backgroundImage: NetworkImage(avatarURL),
+                radius: 20,
+              ),
+              const SizedBox(
+                width: 10
+              ),
+              Text(
+                name,
+                style: AppTextStyles.heading2,
+              ),
+            ],
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(width: 50),
+              Text(
+                proficiencyLevel
+              ),
+            ]
+          ),
+          const SizedBox(height: 50),
+          Row(
+            children: [
+              const SizedBox(width: 50),
+              Column(
+                children: [
+                  Icon(Icons.calendar_month),
+                  Text("15"),
+                  Text("Active Days"),
+                ],
+              ),
+              const SizedBox(width: 50),
+                            Column(
+                children: [
+                  Icon(Icons.arrow_outward_rounded),
+                  Text("92%"),
+                  Text("Precision"),
+                ],
+              ),
+            ],
+          ),
         ],
       ),      
     );

--- a/app/lib/features/homescreen/widgets/user_info_box.dart
+++ b/app/lib/features/homescreen/widgets/user_info_box.dart
@@ -1,0 +1,85 @@
+import 'package:app/core/constants/colors.dart';
+import 'package:app/core/constants/text_styles.dart';
+import 'package:flutter/material.dart';
+
+class UserInfoBox extends StatelessWidget {
+  final String name;
+  final String avatarURL;
+  final String proficiencyLevel;
+
+  const UserInfoBox({
+    super.key,
+    required this.name,
+    required this.avatarURL,
+    required this.proficiencyLevel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.cardShadow,
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ]
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              CircleAvatar(
+                backgroundImage: NetworkImage(avatarURL),
+                radius: 20,
+              ),
+              const SizedBox(
+                width: 10
+              ),
+              Text(
+                name,
+                style: AppTextStyles.heading2,
+              ),
+            ],
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(width: 50),
+              Text(
+                proficiencyLevel
+              ),
+            ]
+          ),
+          const SizedBox(height: 50),
+          Row(
+            children: [
+              const SizedBox(width: 50),
+              Column(
+                children: [
+                  Icon(Icons.calendar_month),
+                  Text("15"),
+                  Text("Active Days"),
+                ],
+              ),
+              const SizedBox(width: 50),
+                            Column(
+                children: [
+                  Icon(Icons.arrow_outward_rounded),
+                  Text("92%"),
+                  Text("Precision"),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),      
+    );
+  }
+}

--- a/app/lib/features/homescreen/widgets/user_info_box.dart
+++ b/app/lib/features/homescreen/widgets/user_info_box.dart
@@ -16,70 +16,89 @@ class UserInfoBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+
     return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: AppColors.cardBackground,
+        color: AppColors.primary.withValues(alpha: 0.2),
         borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.primary, width: 2),
         boxShadow: [
           BoxShadow(
             color: AppColors.cardShadow,
             blurRadius: 10,
             offset: const Offset(0, 2),
           ),
-        ]
+        ],
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // Avatar and Name
           Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               CircleAvatar(
                 backgroundImage: NetworkImage(avatarURL),
-                radius: 20,
+                radius: screenWidth * 0.03,
               ),
-              const SizedBox(
-                width: 10
-              ),
-              Text(
-                name,
-                style: AppTextStyles.heading2,
+              const SizedBox(width: 12),
+              Expanded(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    name,
+                    style: AppTextStyles.heading2,
+                  ),
+                ),
               ),
             ],
           ),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const SizedBox(width: 50),
-              Text(
-                proficiencyLevel
-              ),
-            ]
-          ),
-          const SizedBox(height: 50),
+
+          const SizedBox(height: 8),
+
+          // Proficiency level
           Row(
             children: [
-              const SizedBox(width: 50),
-              Column(
-                children: [
-                  Icon(Icons.calendar_month),
-                  Text("15"),
-                  Text("Active Days"),
-                ],
-              ),
-              const SizedBox(width: 50),
-                            Column(
-                children: [
-                  Icon(Icons.arrow_outward_rounded),
-                  Text("92%"),
-                  Text("Precision"),
-                ],
+              SizedBox(width: screenWidth * 0.10),
+              Expanded(
+                child: Text(
+                  proficiencyLevel,
+                  style: AppTextStyles.heading3,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             ],
+          ),
+
+          const SizedBox(height: 30),
+          // Stats
+          LayoutBuilder(
+            builder: (context, constraints) {
+              return Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,          
+                children: [
+                  _buildStatBox(Icons.calendar_month, "15", "Active Days"),
+                  _buildStatBox(Icons.arrow_outward_rounded, "92%", "Precision"),
+                ],
+              );
+            },
           ),
         ],
       ),      
     );
   }
+
+    Widget _buildStatBox(IconData icon, String value, String label) {
+      return Column(
+        children: [
+          Icon(icon, size: 28),
+          const SizedBox(height: 4),
+          Text(value, style: const TextStyle(fontWeight: FontWeight.bold)),
+          Text(label, style: const TextStyle(fontSize: 12)),
+        ],
+      );
+    }
 }

--- a/app/lib/features/homescreen/widgets/user_info_box.dart
+++ b/app/lib/features/homescreen/widgets/user_info_box.dart
@@ -32,52 +32,7 @@ class UserInfoBox extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              CircleAvatar(
-                backgroundImage: NetworkImage(avatarURL),
-                radius: 20,
-              ),
-              const SizedBox(
-                width: 10
-              ),
-              Text(
-                name,
-                style: AppTextStyles.heading2,
-              ),
-            ],
-          ),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const SizedBox(width: 50),
-              Text(
-                proficiencyLevel
-              ),
-            ]
-          ),
-          const SizedBox(height: 50),
-          Row(
-            children: [
-              const SizedBox(width: 50),
-              Column(
-                children: [
-                  Icon(Icons.calendar_month),
-                  Text("15"),
-                  Text("Active Days"),
-                ],
-              ),
-              const SizedBox(width: 50),
-                            Column(
-                children: [
-                  Icon(Icons.arrow_outward_rounded),
-                  Text("92%"),
-                  Text("Precision"),
-                ],
-              ),
-            ],
-          ),
+          Text('test'),
         ],
       ),      
     );

--- a/app/lib/features/homescreen/widgets/welcome_box.dart
+++ b/app/lib/features/homescreen/widgets/welcome_box.dart
@@ -1,0 +1,90 @@
+import 'package:app/core/constants/colors.dart';
+import 'package:app/core/constants/text_styles.dart';
+import 'package:flutter/material.dart';
+
+class WelcomeBackBox extends StatelessWidget {
+  final String name;
+
+  const WelcomeBackBox({
+    super.key,
+    required this.name,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.primary, width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.cardShadow,
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Greeting
+          Text(
+            "Good to have you back, $name 👋",
+            style: AppTextStyles.heading2,
+          ),
+          const SizedBox(height: 8),
+
+          // Subtext
+          Text(
+            "Continue your progress",
+            style: Theme.of(context).textTheme.bodyMedium ??
+                const TextStyle(fontSize: 14, color: Colors.grey),
+          ),
+          const SizedBox(height: 20),
+
+          // Buttons to continue
+          Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary, // your theme color
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  child: const Text(
+                    "Continue Lesson",
+                    style: TextStyle(color: Colors.white, fontSize: 16),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: null,
+                  style: OutlinedButton.styleFrom(
+                    side: BorderSide(color: AppColors.primary, width: 2),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  child: Text(
+                    "Fast Practice",
+                    style: TextStyle(color: AppColors.primary, fontSize: 16),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Issues worked on for this pull request:
- Issue #109
- Issue #117 

## Changes Made:
### 1. New Home Page (home_page.dart)
- Created a responsive homepage with multiple UI elements:
  - Welcome box with information of the user
  - Continue activity box where a user can continue where they left off
  - Three Activity Cards:
     i. Lessons: Displays the total number of available lessons and the next suggested pronunciation topic.
     ii. Daily Practice: Shows the remaining daily practice time and current completion progress.
     iii. Weekly Goals: Displays weekly progress
### 2. Updates to user_progress_dashboard.dart
- Updated the main AppBar of the application to include the homepage
- Updated the index so that the homepage is the first page when launching the application.
### 3. Comments on the UI elements:
- While the homepage now includes multiple elements including displaying a user, continue activity portion and multiple places to select lessons, daily practices and weekly goals. These are purely UI elements and do not function at the moment because there is no place to currently redirect users to when clicking these buttons.
