### PR TITLE
feat: Redesign Profile page with statistics section and hamburger menu, issue #101

### DIFF
--- a/app/lib/features/dashboard/pages/user_progress_dashboard.dart
+++ b/app/lib/features/dashboard/pages/user_progress_dashboard.dart
@@ -10,6 +10,7 @@ import '../widgets/daily_challenge.dart';
 import '../widgets/progress_visualization_widget.dart';
 import '../widgets/recent_activity_timeline.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:app/features/profile/pages/profile_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -54,7 +55,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
     _screens = [
       const UserProgressDashboard(),
       const DailyChallengePage(),
-      const ProfilePagePlaceholder(),
+      const ProfilePage(),
     ];
   }
 

--- a/app/lib/features/profile/pages/profile_page.dart
+++ b/app/lib/features/profile/pages/profile_page.dart
@@ -1,11 +1,19 @@
 import 'package:flutter/material.dart';
 import '../../../core/constants/colors.dart';
+import '../../dashboard/widgets/progress_visualization_widget.dart';
 
 /// -------------------------------
 ///  PROFILE PAGE
 /// -------------------------------
-class ProfilePage extends StatelessWidget {
+class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  bool _isMenuExpanded = false;
 
   @override
   Widget build(BuildContext context) {
@@ -15,12 +23,10 @@ class ProfilePage extends StatelessWidget {
         preferredSize: const Size.fromHeight(60),
         child: SafeArea(
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: const Row(
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 8),
+            child: Row(
               children: [
-                Icon(Icons.person, color: Colors.blue, size: 28),
-                SizedBox(width: 8),
-                Text(
+                const Text(
                   'Profile',
                   style: TextStyle(
                     fontSize: 24,
@@ -28,16 +34,54 @@ class ProfilePage extends StatelessWidget {
                     color: AppColors.textPrimary,
                   ),
                 ),
+                const Spacer(),
+                GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _isMenuExpanded = !_isMenuExpanded;
+                    });
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.blue.withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Icon(
+                      Icons.menu,
+                      color: Colors.blue,
+                      size: 24,
+                    ),
+                  ),
+                ),
               ],
             ),
           ),
         ),
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            // Profile Header
+      body: Stack(
+        children: [
+          // Backdrop overlay
+          if (_isMenuExpanded)
+            Positioned.fill(
+              child: GestureDetector(
+                onTap: () {
+                  setState(() {
+                    _isMenuExpanded = false;
+                  });
+                },
+                child: Container(
+                  color: Colors.black.withOpacity(0.3),
+                ),
+              ),
+            ),
+          
+          // Main Content
+          SingleChildScrollView(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              children: [
+                  // Profile Header
             Container(
               padding: const EdgeInsets.all(24),
               decoration: BoxDecoration(
@@ -80,54 +124,246 @@ class ProfilePage extends StatelessWidget {
             ),
             const SizedBox(height: 20),
 
-            // Profile Options
-            _buildProfileOption(
-              icon: Icons.settings,
-              title: 'Settings',
-              subtitle: 'App preferences and configuration',
-              onTap: () {
-                // Navigate to settings
-                _showComingSoonDialog(context, 'Settings');
-              },
+            // Statistics Section
+          Align(
+            alignment: Alignment.centerLeft,
+            child: 
+            const Text(
+              'Your Statistics',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: AppColors.textPrimary,
+              ),
             ),
-            const SizedBox(height: 12),
+          ),
+          const SizedBox(height: 16),
 
-            _buildProfileOption(
-              icon: Icons.bar_chart,
-              title: 'Statistics',
-              subtitle: 'View detailed progress statistics',
-              onTap: () {
-                // Navigate to statistics
-                _showComingSoonDialog(context, 'Statistics');
-              },
+            // Quick Overview Cards
+            Row(
+              children: [
+                Expanded(
+                  child: _buildOverviewCard(
+                    'Accuracy Rate',
+                    '89%',
+                    Icons.gps_fixed,
+                    AppColors.success,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _buildOverviewCard(
+                    'Words Practiced',
+                    '247',
+                    Icons.record_voice_over,
+                    AppColors.primary,
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: 20),
 
-            _buildProfileOption(
-              icon: Icons.help_outline,
-              title: 'Help & Support',
-              subtitle: 'Get help and contact support',
-              onTap: () {
-                // Navigate to help
-                _showComingSoonDialog(context, 'Help & Support');
-              },
+                  // Inline statistics visualization
+                  const ProgressVisualizationWidget(),
+
+                // Add bottom padding for tab bar
+                const SizedBox(height: 80),
+              ],
             ),
-            const SizedBox(height: 12),
-
-            _buildProfileOption(
-              icon: Icons.info_outline,
-              title: 'About',
-              subtitle: 'App version and information',
-              onTap: () {
-                // Show about dialog
-                _showAboutDialog(context);
-              },
+          ),
+          
+          // Expandable Menu Overlay
+          if (_isMenuExpanded)
+            Positioned(
+              top: 0,
+              right: 0,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 300),
+                width: MediaQuery.of(context).size.width * 0.5,
+                height: MediaQuery.of(context).size.height,
+                decoration: BoxDecoration(
+                  color: AppColors.cardBackground,
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.3),
+                      blurRadius: 10,
+                      offset: const Offset(-2, 0),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  children: [
+                    // Menu Header
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: Colors.blue.withOpacity(0.1),
+                        border: Border(
+                          bottom: BorderSide(
+                            color: Colors.grey.withOpacity(0.2),
+                            width: 1,
+                          ),
+                        ),
+                      ),
+                      child: const Center(
+                        child: Text(
+                          'Menu',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                            color: AppColors.textPrimary,
+                          ),
+                        ),
+                      ),
+                    ),
+                    
+                    // Menu Options
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          children: [
+                            _buildMenuOption(
+                              icon: Icons.settings,
+                              title: 'Settings',
+                              subtitle: 'App preferences and configuration',
+                              onTap: () {
+                                setState(() {
+                                  _isMenuExpanded = false;
+                                });
+                                _showComingSoonDialog(context, 'Settings');
+                              },
+                            ),
+                            const Divider(height: 1),
+                            _buildMenuOption(
+                              icon: Icons.help_outline,
+                              title: 'Help & Support',
+                              subtitle: 'Get help and contact support',
+                              onTap: () {
+                                setState(() {
+                                  _isMenuExpanded = false;
+                                });
+                                _showComingSoonDialog(context, 'Help & Support');
+                              },
+                            ),
+                            const Divider(height: 1),
+                            _buildMenuOption(
+                              icon: Icons.info_outline,
+                              title: 'About',
+                              subtitle: 'App version and information',
+                              onTap: () {
+                                setState(() {
+                                  _isMenuExpanded = false;
+                                });
+                                _showAboutDialog(context);
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
+          
+        ],
+      ),
+    );
+  }
 
-            // Add bottom padding for tab bar
-            const SizedBox(height: 80),
-          ],
+  Widget _buildMenuOption({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      leading: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Colors.blue.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(8),
         ),
+        child: Icon(icon, color: Colors.blue),
+      ),
+      title: Text(
+        title,
+        style: const TextStyle(
+          fontWeight: FontWeight.w600,
+          color: AppColors.textPrimary,
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(color: Colors.grey[600], fontSize: 12),
+      ),
+      trailing: const Icon(Icons.chevron_right, color: Colors.grey),
+      onTap: onTap,
+    );
+  }
+
+  Widget _buildOverviewCard(
+    String title,
+    String value,
+    IconData icon,
+    Color color,
+  ) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.cardShadow,
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Icon(icon, color: color, size: 24),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: color.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  '+5%',
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 28,
+              fontWeight: FontWeight.bold,
+              color: AppColors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 12,
+              color: Colors.grey[700],
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
- Add dedicated Statistics section with title above overview cards
- Move Settings, Help & Support, and About options to hamburger menu
- Implement right-side sliding menu that covers half screen width
- Add backdrop overlay for better UX when menu is open
- Replace ProfilePagePlaceholder with full ProfilePage in navigation
- Include Accuracy Rate and Words Practiced cards in statistics
- Add inline ProgressVisualizationWidget to profile page
- Improve visual hierarchy by reducing clutter on main profile view
- Fix menu interaction issues and remove duplicate close buttons