### PR TITLE
Add password visibility toggle to password fields

### DIFF
--- a/app/lib/features/authentication/presentation/widgets/text_field.dart
+++ b/app/lib/features/authentication/presentation/widgets/text_field.dart
@@ -26,12 +26,25 @@ class MyTextField extends StatefulWidget {
 }
 
 class _MyTextFieldState extends State<MyTextField> {
+  // controla si se muestra u oculta el texto cuando es contraseña
+  late bool _obscure;
+
+  @override
+  void initState() {
+    super.initState();
+    // si es un campo de password, empezamos ocultando. Si no, da igual
+    _obscure = widget.isPass ?? false;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final bool isPasswordField = widget.isPass ?? false;
+
     return TextFormField(
       controller: widget.controller,
-      obscureText: widget.isPass ?? false,
-      keyboardType: TextInputType.emailAddress,
+      obscureText: isPasswordField ? _obscure : false,
+      keyboardType:
+          isPasswordField ? TextInputType.text : TextInputType.emailAddress,
       style: TextStyle(fontSize: 14.sp, color: AppColors.textPrimary),
       decoration: InputDecoration(
         labelText: widget.labelText,
@@ -67,6 +80,20 @@ class _MyTextFieldState extends State<MyTextField> {
         prefixIcon: widget.icon,
         filled: true,
         fillColor: Colors.grey.shade50,
+
+        suffixIcon: isPasswordField
+            ? IconButton(
+                icon: Icon(
+                  _obscure ? Icons.visibility_off : Icons.visibility,
+                  color: AppColors.textMuted,
+                ),
+                onPressed: () {
+                  setState(() {
+                    _obscure = !_obscure;
+                  });
+                },
+              )
+            : null,
       ),
       validator: widget.validator,
     );


### PR DESCRIPTION
Closes #362

Feat: Implemented password visibility toggle for password fields in the authentication forms.

Changes:
- Updated `MyTextField` to use an internal `_obscure` state when `isPass` is true.
- Added an eye icon (`Icons.visibility` / `Icons.visibility_off`) as a `suffixIcon` for password fields.
- Toggled password visibility when the eye icon is pressed.
- Ensured the Password and Confirm Password fields in `SigninPage` automatically use the new visibility toggle without changing their validation or behavior.

How to test:
- Go to the **Sign Up** screen.
- In the **Password** field:
  - Type a password → text should be hidden by default (dots/bullets).
  - Tap the eye icon → password should become visible.
  - Tap the eye icon again → password should be hidden again.
- Repeat the same steps for the **Confirm Password** field.
- Verify that sign-up still works correctly with valid matching passwords.
